### PR TITLE
fix: errors are not being sent to Sentry

### DIFF
--- a/packages/fnd-server/src/index.ts
+++ b/packages/fnd-server/src/index.ts
@@ -19,6 +19,11 @@ import router from "./router";
 import { registerSentry, registerSentryErrorHandler } from "./utils/sentry";
 
 // setup app
+process.on("uncaughtException", (err) => {
+  log.error(err, "uncaughtException");
+});
+
+// setup app
 const app = express();
 const port = process.env.PORT || process.argv[2] || 8060;
 const http = createServer(app);

--- a/packages/fnd-server/src/utils/sentry.ts
+++ b/packages/fnd-server/src/utils/sentry.ts
@@ -44,9 +44,9 @@ export const registerSentryErrorHandler = (app: Express): void => {
   if (sentryDsn) {
     app.use(
       Sentry.Handlers.errorHandler({
-        shouldHandleError(error) {
-          // Capture all 404 and 500 errors
-          return typeof error.status === "number" ? error.status >= 400 : false;
+        shouldHandleError() {
+          // always send the errors to sentry, will dial down if needed
+          return true;
         },
       })
     );

--- a/packages/fnd-server/src/utils/sentry.ts
+++ b/packages/fnd-server/src/utils/sentry.ts
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/node";
-import * as Tracing from "@sentry/tracing";
 import LoglevelSentryPlugin from "@toruslabs/loglevel-sentry";
 import { Express } from "express";
 import log from "loglevel";
@@ -17,7 +16,7 @@ export const registerSentry = (app: Express): void => {
         new Sentry.Integrations.Http({ tracing: true, breadcrumbs: true }),
 
         // enable Express.js middleware tracing
-        new Tracing.Integrations.Express({
+        new Sentry.Integrations.Express({
           // to trace all requests to the default router
           app,
           // alternatively, you can specify the routes you want to trace:
@@ -50,8 +49,8 @@ export const registerSentryErrorHandler = (app: Express): void => {
     app.use(
       Sentry.Handlers.errorHandler({
         shouldHandleError(error) {
-          // Capture all 404 and 500 errors
-          return typeof error.status === "number" ? error.status >= 400 : false;
+          // Capture all 500 errors
+          return typeof error.status === "number" ? error.status >= 500 : false;
         },
       })
     );


### PR DESCRIPTION
Issue: https://toruslabs.atlassian.net/browse/PD-3415
Currently, all errors are not being sent to Sentry. This will make sure all errors will be captured by Sentry. Will dial down later if needed